### PR TITLE
Fix profile handle parsing with equals sign

### DIFF
--- a/app/whois/page.tsx
+++ b/app/whois/page.tsx
@@ -48,7 +48,9 @@ export default function Who() {
 		if (typeof window === "undefined") return ""
 		const search = window.location.search
 		if (search.startsWith("?")) {
-			return search.substring(1).split("&")[0]
+			const firstParam = search.substring(1).split("&")[0]
+			// Handle cases like "sam=" by splitting on = and taking the part before it
+			return firstParam.split("=")[0]
 		}
 		return ""
 	}


### PR DESCRIPTION
Fix `getHandleFromUrl` to correctly extract profile handles when an `=` character follows them.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7c7243d-cad8-4568-a5d3-b0ef24dcb476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7c7243d-cad8-4568-a5d3-b0ef24dcb476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

