### PR TITLE
Cloudflare deployment / pr preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,44 +1,20 @@
-name: Deploy
+name: Preview
 
 on:
-  push:
+  pull_request:
     branches: ["main"]
-  workflow_dispatch:
 
 concurrency:
-  group: "deploy"
-  cancel-in-progress: false
+  group: "preview-${{ github.head_ref }}"
+  cancel-in-progress: true
 
 permissions:
   contents: read
+  pull-requests: write
   deployments: write
 
 jobs:
-  migrate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
-        with:
-          version: latest
-
-      - name: Link Supabase project
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-
-      - name: Push database migrations
-        run: supabase db push --linked --include-all --yes
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-
-  deploy:
-    needs: migrate
+  deploy-preview:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Replaces the GitHub Pages production deploy with Cloudflare Pages, and adds automatic PR preview deployments.

Every PR targeting main will now get a Cloudflare Pages preview deployed on each push, with a comment posted automatically containing the preview URL. The comment updates in place as new commits are pushed.

On merge to main, the same workflow deploys to the production Cloudflare Pages project after running Supabase migrations.

All workflow actions are pinned to SHA for supply chain security.

## Cloudflare Pages docs

https://developers.cloudflare.com/pages

## Secrets required

Two secrets need to be added to the repo before this works.

CF_API_TOKEN: a Cloudflare API token with Cloudflare Pages Edit permission
CF_ACCOUNT_ID: your Cloudflare account ID, found in the Cloudflare dashboard sidebar

A Pages project named devx-network also needs to exist in Cloudflare. Create it as a Direct Upload project so it does not try to connect to Git directly.