### PR TITLE
Inline public supabase vars

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SUPABASE_URL: "https://psbmuerdpmkajkkldqtz.supabase.co"
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBzYm11ZXJkcG1rYWpra2xkcXR6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjMzNDE1NjcsImV4cCI6MjA3ODkxNzU2N30.JKaPS9tajIe6YJklEAdlih8a5xA-XgD3hStwKOEiihI"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Forks can’t assess vars easily. We could do it with  pull_request_target, but, that’s complicated.